### PR TITLE
fix: json strings

### DIFF
--- a/src/engine/intrinsic.rs
+++ b/src/engine/intrinsic.rs
@@ -127,6 +127,12 @@ where
                 params: vec![Type::Unit, Type::Unit],
                 ret: Type::Unit,
             }))),
+            "toJsonStr" => Ok(Some(Value::Function(Function {
+                id: var.id,
+                name: var.name.clone(),
+                params: vec![A::t()],
+                ret: Type::String,
+            }))),
             "toStr" => Ok(Some(Value::Function(Function {
                 id: var.id,
                 name: var.name.clone(),
@@ -364,6 +370,10 @@ where
                 }
             }
             "toStr" => {
+                let x = args.pop_front().unwrap();
+                Ok(Value::String(x.to_string()))
+            }
+            "toJsonStr" => {
                 let x = args.pop_front().unwrap();
                 Ok(Value::String(
                     serde_json::to_string(&x).expect("value failed to serialize"),

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -474,9 +474,9 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_to_str() {
+    async fn test_to_strs() {
         let mut parser =
-            Parser::new(Token::tokenize("test.rex", r#"json ( '{ "hello": '++ (toStr ( 1 + 2 )) ++ ', "world":' ++ ( toStr ( json '{"foo": "bar"}')) ++ ' }' ) "#).unwrap());
+            Parser::new(Token::tokenize("test.rex", r#"json ( '{ "hello": '++ (toStr ( 1 + 2 )) ++ ', "world":' ++ ( toJsonStr ( json '{"foo": "bar"}')) ++ ' }' ) "#).unwrap());
         let mut resolver = Resolver::new();
         let ir = resolver.resolve(parser.parse_expr().unwrap()).unwrap();
         let mut engine = Engine::new(resolver.curr_id);
@@ -485,7 +485,7 @@ mod test {
         assert_eq!(
             value,
             Value::Record(BTreeMap::from([
-                ("hello".to_string(), serde_json::json!( {"u64": 3} )),
+                ("hello".to_string(), serde_json::json!(3)),
                 (
                     "world".to_string(),
                     serde_json::json!({ "record": { "foo": "bar" } })


### PR DESCRIPTION
toStr currently uses the to_str function, which is a formatting print and not a json string. 

This PR fixes the issue so that we can construct nested json objects