### PR TITLE
feat: make dispenser cloneable

### DIFF
--- a/rex-ast/src/id.rs
+++ b/rex-ast/src/id.rs
@@ -22,6 +22,7 @@ impl Display for Id {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdDispenser {
     id: Id,
 }


### PR DESCRIPTION
We want this because when the ftable gets set up we want to be able to maintain the current sets of ids, and resume producing new ones from the last index