### PR TITLE
Use persistent data structures to reduce cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae2ed21cd55021f05707a807a5fc85695dafb98832921f6cfa06db67ca5b869"
+dependencies = [
+ "triomphe",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +409,7 @@ dependencies = [
  "rex-ast",
  "rex-parser",
  "rex-resolver",
+ "rpds",
  "serde",
  "serde_json",
  "thiserror",
@@ -421,6 +431,16 @@ version = "0.1.0"
 dependencies = [
  "rex-ast",
  "thiserror",
+]
+
+[[package]]
+name = "rpds"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e15515d3ce3313324d842629ea4905c25a13f81953eadb88f85516f59290a4"
+dependencies = [
+ "archery",
+ "serde",
 ]
 
 [[package]]
@@ -528,6 +548,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8f7726da4807b58ea5c96fdc122f80702030edc33b35aff9190a51148ccc85"
 
 [[package]]
 name = "unicode-ident"

--- a/rex-engine/Cargo.toml
+++ b/rex-engine/Cargo.toml
@@ -14,9 +14,10 @@ rex-parser = { path = "../rex-parser" }
 rex-resolver = { path = "../rex-resolver" }
 thiserror = { version = "1.0" }
 tokio = { version = "1.27.0", features = ["macros", "rt"] }
+rpds = { version = "1.1" }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 
 [features]
 default = ["serde"]
-serde = ["dep:serde_json", "dep:serde"]
+serde = ["dep:serde_json", "dep:serde", "rpds/serde"]

--- a/rex-engine/src/apply.rs
+++ b/rex-engine/src/apply.rs
@@ -129,7 +129,7 @@ where
         // Id
         Value::Id(id) => {
             match ctx.get(&id) {
-                Some(Value::Id(id)) => Ok(Value::Id(id)), // We do not want to recurse infinitely
+                Some(Value::Id(id)) => Ok(Value::Id(*id)), // We do not want to recurse infinitely
                 _ => match ftable.lookup(ctx, &id).await {
                     Ok(v) => Ok(apply0(ctx, ftable, state, v).await?),
                     Err(e) => Err(e),

--- a/rex-engine/src/apply.rs
+++ b/rex-engine/src/apply.rs
@@ -3,11 +3,11 @@ use std::collections::BTreeMap;
 use futures::future;
 
 use crate::{
+    context::Context,
     error::Error,
     eval,
     ftable::Ftable,
     value::{Closure, Data, DataFields, FunctionLike, NamedDataFields, UnnamedDataFields, Value},
-    Context,
 };
 
 pub async fn apply<S: Send + Sync + 'static>(
@@ -45,8 +45,8 @@ pub async fn apply<S: Send + Sync + 'static>(
             }
             FunctionLike::Lambda(lam) => {
                 let mut new_ctx = ctx.clone();
-                new_ctx.vars.insert(lam.var.id, arg);
-                new_ctx.extend(closure.captured_ctx);
+                new_ctx.insert(lam.var.id, arg);
+                new_ctx.extend(&closure.captured_ctx);
                 eval(&new_ctx, ftable, state, *lam.body.clone()).await
             }
         },
@@ -58,12 +58,15 @@ pub async fn apply<S: Send + Sync + 'static>(
 }
 
 #[async_recursion::async_recursion]
-pub async fn apply0<S: Send + Sync + 'static>(
+pub async fn apply0<S>(
     ctx: &Context,
     ftable: &Ftable<S>,
     state: &S,
     base: Value,
-) -> Result<Value, Error> {
+) -> Result<Value, Error>
+where
+    S: Send + Sync + 'static,
+{
     match base {
         // Basics
         Value::Null => Ok(Value::Null),
@@ -125,8 +128,8 @@ pub async fn apply0<S: Send + Sync + 'static>(
         },
         // Id
         Value::Id(id) => {
-            match ctx.vars.get(&id) {
-                Some(Value::Id(id)) => Ok(Value::Id(*id)), // We do not want to recurse infinitely
+            match ctx.get(&id) {
+                Some(Value::Id(id)) => Ok(Value::Id(id)), // We do not want to recurse infinitely
                 _ => match ftable.lookup(ctx, &id).await {
                     Ok(v) => Ok(apply0(ctx, ftable, state, v).await?),
                     Err(e) => Err(e),

--- a/rex-engine/src/context.rs
+++ b/rex-engine/src/context.rs
@@ -34,8 +34,8 @@ impl Context {
         }
     }
 
-    pub fn get(&self, k: &Id) -> Option<Value> {
-        self.vars.get(k).cloned()
+    pub fn get(&self, k: &Id) -> Option<&Value> {
+        self.vars.get(k)
     }
 }
 

--- a/rex-engine/src/context.rs
+++ b/rex-engine/src/context.rs
@@ -1,0 +1,54 @@
+use std::fmt::{self, Display, Formatter};
+
+use rex_ast::id::Id;
+use rpds::HashTrieMapSync;
+
+use crate::value::Value;
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Context {
+    vars: HashTrieMapSync<Id, Value>,
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self {
+            vars: HashTrieMapSync::new_sync(),
+        }
+    }
+
+    pub fn insert(&mut self, k: Id, v: Value) {
+        self.vars.insert_mut(k, v);
+    }
+
+    pub fn extend(&mut self, rhs: &Context) {
+        for (k, v) in rhs.vars.iter() {
+            self.vars.insert_mut(*k, v.clone());
+        }
+    }
+
+    pub fn get(&self, k: &Id) -> Option<Value> {
+        self.vars.get(k).cloned()
+    }
+}
+
+impl Display for Context {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        for (i, (k, v)) in self.vars.iter().enumerate() {
+            k.fmt(f)?;
+            "←".fmt(f)?;
+            v.fmt(f)?;
+            if i + 1 < self.vars.size() {
+                "; ".fmt(f)?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/rex-engine/src/lib.rs
+++ b/rex-engine/src/lib.rs
@@ -112,7 +112,7 @@ async fn eval_var<S: Send + Sync + 'static>(
     var: Var,
 ) -> Result<Value, Error> {
     match ctx.get(&var.id) {
-        Some(value) => Ok(value),
+        Some(value) => Ok(value.clone()),
         _ => match ftable.lookup(ctx, &var.id).await {
             Ok(Value::Function(function)) if function.params.is_empty() => {
                 // This is a nullary function


### PR DESCRIPTION
currently, rex uses too much memory because every time a `let-in` binding or a `lambda` is used, the `Context` is cloned. using a naive `HashMap` means that all of the values bound to an existing variable are deep-cloned when a new variable is defined.

this PR aims to fix this issue by moving away from `std::collections::HashMap` and instead using `rpds::HashTrieMap` which uses a persistent data structure under-the-hood. this means that when a `Context` is cloned, a shallow clone is used. however, mutations are still possible, and only the minimum necessary cloning is done in order to achieve the necessary mutations.

there are still a lot of clones that can be further reduces. however, we do not need to wait in order to merge this PR. this PR opens the way for removing additional clones, but should also have some immediate impact on memory usage.

tests are passing.
clippy is happy.