### PR TITLE
Feat/negate

### DIFF
--- a/rex-ast/src/pattern.rs
+++ b/rex-ast/src/pattern.rs
@@ -1,0 +1,126 @@
+use std::fmt::{self, Display, Formatter};
+
+use crate::ast::Var;
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum Pattern {
+    Var(Var),
+    Tuple(Vec<Pattern>),
+    List(ListPattern),
+    Data(DataPattern),
+}
+
+impl Display for Pattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Var(x) => x.fmt(f),
+            Self::Tuple(xs) => {
+                '('.fmt(f)?;
+                for (i, x) in xs.iter().enumerate() {
+                    x.fmt(f)?;
+                    if i < xs.len() - 1 || xs.len() == 1 {
+                        ", ".fmt(f)?;
+                    }
+                }
+                ')'.fmt(f)
+            }
+            Self::List(x) => x.fmt(f),
+            Self::Data(x) => x.fmt(f),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum ListPattern {
+    Var(Var),                                 // xs
+    Elems(Vec<Pattern>),                      // [x, y, z]
+    HeadTail(Box<Pattern>, Box<ListPattern>), // x:xs
+}
+
+impl Display for ListPattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Var(x) => x.fmt(f),
+            Self::Elems(xs) => {
+                '['.fmt(f)?;
+                for (i, x) in xs.iter().enumerate() {
+                    x.fmt(f)?;
+                    if i < xs.len() - 1 {
+                        ", ".fmt(f)?;
+                    }
+                }
+                ']'.fmt(f)
+            }
+            Self::HeadTail(x, xs) => {
+                x.fmt(f)?;
+                ':'.fmt(f)?;
+                xs.fmt(f)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum DataPattern {
+    Constructor(String, Option<Vec<DictPattern>>), // Foo { x, y, w = z:zs }
+}
+
+impl Display for DataPattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Constructor(x, xs) => {
+                x.fmt(f)?;
+                if let Some(xs) = xs {
+                    '{'.fmt(f)?;
+                    for (i, x) in xs.iter().enumerate() {
+                        x.fmt(f)?;
+                        if i < xs.len() - 1 {
+                            ", ".fmt(f)?;
+                        }
+                    }
+                    '}'.fmt(f)?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(rename_all = "lowercase")
+)]
+pub enum DictPattern {
+    Key(Var),                       // w
+    KeyMatch(String, Box<Pattern>), // w = x:xs
+}
+
+impl Display for DictPattern {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Key(key) => key.fmt(f),
+            Self::KeyMatch(key, x) => {
+                key.fmt(f)?;
+                " = ".fmt(f)?;
+                x.fmt(f)
+            }
+        }
+    }
+}

--- a/rex-engine/src/apply.rs
+++ b/rex-engine/src/apply.rs
@@ -58,12 +58,15 @@ pub async fn apply<S: Send + Sync + 'static>(
 }
 
 #[async_recursion::async_recursion]
-pub async fn apply0<S: Send + Sync + 'static>(
+pub async fn apply0<S>(
     ctx: &Context,
     ftable: &Ftable<S>,
     state: &S,
     base: Value,
-) -> Result<Value, Error> {
+) -> Result<Value, Error>
+where
+    S: Send + Sync + 'static,
+{
     match base {
         // Basics
         Value::Null => Ok(Value::Null),

--- a/rex-engine/src/ftable.rs
+++ b/rex-engine/src/ftable.rs
@@ -139,6 +139,36 @@ impl<S: Send + Sync + 'static> Ftable<S> {
         this.register_function(
             Function {
                 id: id_dispenser.next(),
+                name: "negate".to_string(),
+                params: vec![a!()],
+                ret: a!(),
+            },
+            Box::new(|_ctx, _runner, _state, args| {
+                Box::pin(async move {
+                    match args.first() {
+                        // Wrong number of arguments
+                        None => Err(Error::ExpectedArguments {
+                            expected: 1,
+                            got: args.len(),
+                            trace: Default::default(),
+                        }),
+                        // Implementation
+                        Some(Value::Uint(x)) => Ok(Value::Int(-(*x as i64))),
+                        Some(Value::Int(x)) => Ok(Value::Int(-x)),
+                        Some(Value::Float(x)) => Ok(Value::Float(-x)),
+                        // Bad types
+                        Some(y) => Err(Error::UnexpectedType {
+                            expected: Type::Uint,
+                            got: y.clone(),
+                            trace: Default::default(),
+                        }),
+                    }
+                })
+            }),
+        );
+        this.register_function(
+            Function {
+                id: id_dispenser.next(),
                 name: "-".to_string(),
                 params: vec![a!(), a!()],
                 ret: a!(),
@@ -147,12 +177,15 @@ impl<S: Send + Sync + 'static> Ftable<S> {
                 Box::pin(async move {
                     match (args.first(), args.get(1)) {
                         // Wrong number of arguments
-                        (_, None) | (None, _) => Err(Error::ExpectedArguments {
+                        (None, None) | (None, _) => Err(Error::ExpectedArguments {
                             expected: 2,
                             got: args.len(),
                             trace: Default::default(),
                         }),
                         // Implementation
+                        (Some(Value::Uint(x)), None) => Ok(Value::Int(-(*x as i64))),
+                        (Some(Value::Int(x)), None) => Ok(Value::Int(-x)),
+                        (Some(Value::Float(x)), None) => Ok(Value::Float(-x)),
                         (Some(Value::Uint(x)), Some(Value::Uint(y))) => Ok(Value::Uint(x - y)),
                         (Some(Value::Int(x)), Some(Value::Int(y))) => Ok(Value::Int(x - y)),
                         (Some(Value::Float(x)), Some(Value::Float(y))) => Ok(Value::Float(x - y)),

--- a/rex-engine/src/ftable.rs
+++ b/rex-engine/src/ftable.rs
@@ -177,15 +177,12 @@ impl<S: Send + Sync + 'static> Ftable<S> {
                 Box::pin(async move {
                     match (args.first(), args.get(1)) {
                         // Wrong number of arguments
-                        (None, None) | (None, _) => Err(Error::ExpectedArguments {
+                        (None, None) | (None, _) | (_, None) => Err(Error::ExpectedArguments {
                             expected: 2,
                             got: args.len(),
                             trace: Default::default(),
                         }),
                         // Implementation
-                        (Some(Value::Uint(x)), None) => Ok(Value::Int(-(*x as i64))),
-                        (Some(Value::Int(x)), None) => Ok(Value::Int(-x)),
-                        (Some(Value::Float(x)), None) => Ok(Value::Float(-x)),
                         (Some(Value::Uint(x)), Some(Value::Uint(y))) => Ok(Value::Uint(x - y)),
                         (Some(Value::Int(x)), Some(Value::Int(y))) => Ok(Value::Int(x - y)),
                         (Some(Value::Float(x)), Some(Value::Float(y))) => Ok(Value::Float(x - y)),

--- a/rex-engine/src/lib.rs
+++ b/rex-engine/src/lib.rs
@@ -407,6 +407,23 @@ mod test {
     }
 
     #[tokio::test]
+    async fn negate() {
+        let mut parser = Parser::new(Token::tokenize("-42").unwrap());
+        let expr = parser.parse_expr().unwrap();
+        let state = ();
+
+        let mut id_dispenser = parser.id_dispenser;
+        let ftable = Ftable::with_intrinsics(&mut id_dispenser);
+
+        let mut scope = ftable.scope();
+        let ctx = Context::new();
+        let ast = resolve(&mut id_dispenser, &mut scope, expr).unwrap();
+        let val = eval(&ctx, &ftable, &state, ast).await.unwrap();
+
+        assert_eq!(val, Value::Int(-42))
+    }
+
+    #[tokio::test]
     async fn math_with_precedence() {
         let mut parser = Parser::new(Token::tokenize("1 + 2 * 3").unwrap());
         let expr = parser.parse_expr().unwrap();

--- a/rex-engine/src/lib.rs
+++ b/rex-engine/src/lib.rs
@@ -64,12 +64,10 @@ impl Display for Context {
 }
 
 #[async_recursion::async_recursion]
-pub async fn eval<S: Send + Sync + 'static>(
-    ctx: &Context,
-    ftable: &Ftable<S>,
-    state: &S,
-    ast: AST,
-) -> Result<Value, Error> {
+pub async fn eval<S>(ctx: &Context, ftable: &Ftable<S>, state: &S, ast: AST) -> Result<Value, Error>
+where
+    S: Send + Sync + 'static,
+{
     let trace_node = ast.clone();
     match ast {
         AST::Null(_span) => Ok(Value::Null),

--- a/rex-parser/src/lib.rs
+++ b/rex-parser/src/lib.rs
@@ -559,7 +559,7 @@ impl Parser {
         Ok(AST::Call(Call::new(
             Span::from_begin_end(span_token.begin, expr.span().end),
             self.id_dispenser.next(),
-            Var::new(span_token, id_neg, "-"),
+            Var::new(span_token, id_neg, "negate"),
             expr,
         )))
     }


### PR DESCRIPTION
includes some initial impl work for pattern matching, but it is unused outside of parsing. 

however, the PR is focused on allowing `- x` unary operator and not having that interpreted as `(-) x` which would return a lambda expecting one more argument for the binary `(-)` operator