### PR TITLE
Initial support for Result & Option

### DIFF
--- a/rex-ast/src/expr.rs
+++ b/rex-ast/src/expr.rs
@@ -77,7 +77,7 @@ pub enum Expr {
     Tuple(Id, Span, Vec<Expr>),             // (e1, e2, e3)
     List(Id, Span, Vec<Expr>),              // [e1, e2, e3]
     Dict(Id, Span, BTreeMap<String, Expr>), // {k1 = v1, k2 = v2}
-    Named(Id, Span, String, Box<Expr>), //  MyVariant1 {k1 = v1, k2 = v2}
+    Named(Id, Span, String, Option<Box<Expr>>), //  MyVariant1 {k1 = v1, k2 = v2}
     Var(Var),                                       // x
     App(Id, Span, Box<Expr>, Box<Expr>),            // f x
     Lam(Id, Span, Scope, Var, Box<Expr>),           // λx → e
@@ -213,7 +213,9 @@ impl Expr {
             }
             Self::Named(id, _span, _name, inner) => {
                 *id = Id::default();
-                inner.reset_ids();
+                if let Some(inner) = inner {
+                    inner.reset_ids();
+                }
             }
             Self::Var(var) => var.reset_id(),
             Self::App(id, _span, g, x) => {
@@ -275,7 +277,9 @@ impl Expr {
             }
             Self::Named(_, span, _name, inner) => {
                 *span = Span::default();
-                inner.reset_spans();
+                if let Some(inner) = inner {
+                    inner.reset_spans();
+                }
             }
             Self::Var(var) => var.reset_span(),
             Self::App(_, span, g, x) => {
@@ -353,9 +357,12 @@ impl Display for Expr {
             }
             Self::Named(_id, _span, name, inner) => {
                 name.fmt(f)?;
-                '('.fmt(f)?;
-                inner.fmt(f)?;
-                ')'.fmt(f)
+                if let Some(inner) = inner {
+                    '('.fmt(f)?;
+                    inner.fmt(f)?;
+                    ')'.fmt(f)?;
+                }
+                Ok(())
             }
             Self::Var(var) => var.fmt(f),
             Self::App(_id, _span, g, x) => {

--- a/rex-ast/src/macros.rs
+++ b/rex-ast/src/macros.rs
@@ -185,8 +185,24 @@ macro_rules! n {
         $crate::expr::Expr::Named(
             $crate::id::Id::new(),
             ::rex_lexer::span::Span::default(),
-            $n.to_string(),
-            Box::new($x),
+            ($n).to_string(),
+            ($x).map(|x| Box::new(x)),
+        )
+    };
+    ($span:expr; $n: expr, $x:expr) => {
+        $crate::expr::Expr::Named(
+            $crate::id::Id::new(),
+            ($span).into(),
+            ($n).to_string(),
+            ($x).map(|x| Box::new(x)),
+        )
+    };
+    ($id:expr, $span:expr; $n: expr, $x:expr) => {
+        $crate::expr::Expr::Named(
+            ($id).into(),
+            ($span).into(),
+            ($n).to_string(),
+            ($x).map(|x| Box::new(x)),
         )
     };
 }

--- a/rex-ast/src/macros.rs
+++ b/rex-ast/src/macros.rs
@@ -180,6 +180,18 @@ macro_rules! d {
 }
 
 #[macro_export]
+macro_rules! n {
+    ($n: expr, $x:expr) => {
+        $crate::expr::Expr::Named(
+            $crate::id::Id::new(),
+            ::rex_lexer::span::Span::default(),
+            $n.to_string(),
+            Box::new($x),
+        )
+    };
+}
+
+#[macro_export]
 macro_rules! v {
     ($x:expr) => {
         $crate::expr::Expr::Var($crate::expr::Var {

--- a/rex-engine/src/codec.rs
+++ b/rex-engine/src/codec.rs
@@ -94,6 +94,13 @@ impl Encode for String {
     }
 }
 
+impl Encode for ()
+{
+    fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
+        Ok(Expr::Tuple(id, span, vec![]))
+    }
+}
+
 impl<T0> Encode for (T0,)
 where
     T0: Encode,
@@ -374,6 +381,13 @@ impl Decode for String {
                 got: v.clone(),
             }),
         }
+    }
+}
+
+impl Decode for ()
+{
+    fn try_decode(_v: &Expr) -> Result<Self, Error> {
+        Ok(())
     }
 }
 

--- a/rex-engine/src/codec.rs
+++ b/rex-engine/src/codec.rs
@@ -178,10 +178,10 @@ where
     fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
         match self {
             Ok(x) => {
-                Ok(Expr::Named(id, span, "Ok".to_string(), Box::new(x.try_encode(id, span)?)))
+                Ok(Expr::Named(id, span, "Ok".to_string(), Some(Box::new(x.try_encode(id, span)?))))
             }
             Err(x) => {
-                Ok(Expr::Named(id, span, "Err".to_string(), Box::new(x.try_encode(id, span)?)))
+                Ok(Expr::Named(id, span, "Err".to_string(), Some(Box::new(x.try_encode(id, span)?))))
             }
         }
     }
@@ -194,10 +194,10 @@ where
     fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
         match self {
             Some(x) => {
-                Ok(Expr::Named(id, span, "Some".to_string(), Box::new(x.try_encode(id, span)?)))
+                Ok(Expr::Named(id, span, "Some".to_string(), Some(Box::new(x.try_encode(id, span)?))))
             }
             None => {
-                Ok(Expr::Named(id, span, "None".to_string(), Box::new(Expr::Tuple(id, span, vec![]))))
+                Ok(Expr::Named(id, span, "None".to_string(), None))
             }
         }
     }
@@ -507,21 +507,21 @@ where
 
 impl<T, E> Decode for Result<T, E>
 where
-    T: Decode,
-    E: Decode,
+    T: Decode + ToType,
+    E: Decode + ToType,
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Named(_id, _span, name, x) if name == "Ok" => {
+            Expr::Named(_id, _span, name, Some(x)) if name == "Ok" => {
                 Ok(Ok(T::try_decode(x)?))
             }
-            Expr::Named(_id, _span, name, x) if name == "Err" => {
+            Expr::Named(_id, _span, name, Some(x)) if name == "Err" => {
                 Ok(Err(E::try_decode(x)?))
             }
             _ => Err(Error::ExpectedTypeGotValue {
                 expected: Type::Result(
-                    Box::new(Type::Var(Id::new())),
-                    Box::new(Type::Var(Id::new()))),
+                    Box::new(T::to_type()),
+                    Box::new(E::to_type())),
                 got: v.clone(),
             }),
         }
@@ -530,18 +530,18 @@ where
 
 impl<T> Decode for Option<T>
 where
-    T: Decode
+    T: Decode + ToType
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Named(_id, _span, name, x) if name == "Some" => {
+            Expr::Named(_id, _span, name, Some(x)) if name == "Some" => {
                 Ok(Some(T::try_decode(x)?))
             }
-            Expr::Named(_id, _span, name, _x) if name == "None" => {
+            Expr::Named(_id, _span, name, None) if name == "None" => {
                 Ok(None)
             }
             _ => Err(Error::ExpectedTypeGotValue {
-                expected: Type::Option(Box::new(Type::Var(Id::new()))),
+                expected: Type::Option(Box::new(T::to_type())),
                 got: v.clone(),
             }),
         }

--- a/rex-engine/src/codec.rs
+++ b/rex-engine/src/codec.rs
@@ -386,8 +386,16 @@ impl Decode for String {
 
 impl Decode for ()
 {
-    fn try_decode(_v: &Expr) -> Result<Self, Error> {
-        Ok(())
+    fn try_decode(v: &Expr) -> Result<Self, Error> {
+        match v {
+            Expr::Tuple(_id, _span, xs) if xs.len() == 0 => {
+                Ok(())
+            }
+            _ => Err(Error::ExpectedTypeGotValue {
+                expected: Self::to_type(),
+                got: v.clone(),
+            }),
+        }
     }
 }
 
@@ -397,17 +405,11 @@ where
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Tuple(_id, _span, xs) => {
-                if xs.len() != 1 {
-                    return Err(Error::ExpectedTypeGotValue {
-                        expected: Self::to_type(),
-                        got: v.clone(),
-                    });
-                }
+            Expr::Tuple(_id, _span, xs) if xs.len() == 1 => {
                 Ok((T0::try_decode(&xs[0])?,))
             }
             _ => Err(Error::ExpectedTypeGotValue {
-                expected: Type::Int,
+                expected: Self::to_type(),
                 got: v.clone(),
             }),
         }
@@ -421,17 +423,11 @@ where
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Tuple(_id, _span, xs) => {
-                if xs.len() != 2 {
-                    return Err(Error::ExpectedTypeGotValue {
-                        expected: Self::to_type(),
-                        got: v.clone(),
-                    });
-                }
+            Expr::Tuple(_id, _span, xs) if xs.len() == 2 => {
                 Ok((T0::try_decode(&xs[0])?, T1::try_decode(&xs[1])?))
             }
             _ => Err(Error::ExpectedTypeGotValue {
-                expected: Type::Int,
+                expected: Self::to_type(),
                 got: v.clone(),
             }),
         }
@@ -446,13 +442,7 @@ where
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Tuple(_id, _span, xs) => {
-                if xs.len() != 3 {
-                    return Err(Error::ExpectedTypeGotValue {
-                        expected: Self::to_type(),
-                        got: v.clone(),
-                    });
-                }
+            Expr::Tuple(_id, _span, xs) if xs.len() == 3 => {
                 Ok((
                     T0::try_decode(&xs[0])?,
                     T1::try_decode(&xs[1])?,
@@ -460,7 +450,7 @@ where
                 ))
             }
             _ => Err(Error::ExpectedTypeGotValue {
-                expected: Type::Int,
+                expected: Self::to_type(),
                 got: v.clone(),
             }),
         }
@@ -476,13 +466,7 @@ where
 {
     fn try_decode(v: &Expr) -> Result<Self, Error> {
         match v {
-            Expr::Tuple(_id, _span, xs) => {
-                if xs.len() != 4 {
-                    return Err(Error::ExpectedTypeGotValue {
-                        expected: Self::to_type(),
-                        got: v.clone(),
-                    });
-                }
+            Expr::Tuple(_id, _span, xs) if xs.len() == 4 => {
                 Ok((
                     T0::try_decode(&xs[0])?,
                     T1::try_decode(&xs[1])?,
@@ -491,7 +475,7 @@ where
                 ))
             }
             _ => Err(Error::ExpectedTypeGotValue {
-                expected: Type::Int,
+                expected: Self::to_type(),
                 got: v.clone(),
             }),
         }

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -304,6 +304,31 @@ where
             })
         })?;
 
+        // Result
+        this.register_fn1("Ok", |_ctx: &Context<_>, x: A| Ok(Ok::<A, B>(x)))?;
+        this.register_fn1("Err", |_ctx: &Context<_>, x: B| Ok(Err::<A, B>(x)))?;
+        this.register_fn_async2("map_result", |ctx, f: Func<A, B>, x: Result<A, C>| {
+            Box::pin(async move {
+                match x {
+                    Ok(x) => Ok(Ok(B(apply(ctx, &f, &x).await?))),
+                    Err(e) => Ok(Err(e)),
+                }
+            })
+        })?;
+
+
+        // Option
+        this.register_fn0("None", |_ctx: &Context<_>| Ok(None::<A>))?;
+        this.register_fn1("Some", |_ctx: &Context<_>, x: A| Ok(Some(x)))?;
+        this.register_fn_async2("map_option", |ctx, f: Func<A, B>, x: Option<A>| {
+            Box::pin(async move {
+                match x {
+                    Some(x) => Ok(Some(B(apply(ctx, &f, &x).await?))),
+                    None => Ok(None),
+                }
+            })
+        })?;
+
         Ok(this)
     }
 

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -13,7 +13,7 @@ use crate::{
     codec::{Decode, Encode, Func},
     error::Error,
     eval::{apply, Context},
-    ftable::{Ftable, A, B, C, D},
+    ftable::{Ftable, A, B, C, D, E},
 };
 
 macro_rules! impl_register_fn_core {
@@ -307,7 +307,7 @@ where
         // Result
         this.register_fn1("Ok", |_ctx: &Context<_>, x: A| Ok(Ok::<A, B>(x)))?;
         this.register_fn1("Err", |_ctx: &Context<_>, x: B| Ok(Err::<A, B>(x)))?;
-        this.register_fn_async2("map_result", |ctx, f: Func<A, B>, x: Result<A, C>| {
+        this.register_fn_async2("map_result", |ctx, f: Func<A, B>, x: Result<A, E>| {
             Box::pin(async move {
                 match x {
                     Ok(x) => Ok(Ok(B(apply(ctx, &f, &x).await?))),

--- a/rex-engine/src/eval.rs
+++ b/rex-engine/src/eval.rs
@@ -873,7 +873,7 @@ pub mod test {
                 .await
                 .unwrap();
         assert_eq!(res_type, list!(result!(uint!(), string!())));
-        assert_expr_eq!(res, l!(n!("Ok", u!(4)), n!("Err", s!("bad"))); ignore span);
+        assert_expr_eq!(res, l!(n!("Ok", Some(u!(4))), n!("Err", Some(s!("bad")))); ignore span);
 
         let (res, res_type) =
             parse_infer_and_eval(r#"
@@ -887,7 +887,11 @@ pub mod test {
                 .await
                 .unwrap();
         assert_eq!(res_type, list!(result!(list!(uint!()), string!())));
-        assert_expr_eq!(res, l!(n!("Ok", l!(u!(4), u!(5), u!(6))), n!("Err", s!("bad"))); ignore span);
+        assert_expr_eq!(
+            res,
+            l!(n!("Ok", Some(l!(u!(4), u!(5), u!(6)))),
+               n!("Err", Some(s!("bad"))));
+            ignore span);
     }
 
     #[tokio::test]
@@ -897,7 +901,7 @@ pub mod test {
                 .await
                 .unwrap();
         assert_eq!(res_type, list!(option!(uint!())));
-        assert_expr_eq!(res, l!(n!("Some", u!(4)), n!("None", tup!())); ignore span);
+        assert_expr_eq!(res, l!(n!("Some", Some(u!(4))), n!("None", None)); ignore span);
 
         let (res, res_type) =
             parse_infer_and_eval(r#"
@@ -911,7 +915,11 @@ pub mod test {
                 .await
                 .unwrap();
         assert_eq!(res_type, list!(option!(list!(uint!()))));
-        assert_expr_eq!(res, l!(n!("Some", l!(u!(4), u!(5), u!(6))), n!("None", tup!())); ignore span);
+        assert_expr_eq!(
+            res,
+            l!(n!("Some", Some(l!(u!(4), u!(5), u!(6)))),
+               n!("None", None));
+            ignore span);
     }
 
     #[tokio::test]

--- a/rex-parser/src/lib.rs
+++ b/rex-parser/src/lib.rs
@@ -273,6 +273,15 @@ impl Parser {
 
         // Parse the inner expression.
         let mut expr = match self.current_token() {
+            Some(Token::ParenR(span, ..)) => {
+                self.next_token();
+                // Empty tuple
+                return Ok(Expr::Tuple(
+                    Id::new(),
+                    Span::from_begin_end(span_begin.begin, span.end),
+                    vec![],
+                ));
+            }
             Some(Token::Add(span, ..)) => {
                 self.next_token();
                 Expr::Var(Var::with_span(span, "+"))

--- a/rex-type-system/src/constraint.rs
+++ b/rex-type-system/src/constraint.rs
@@ -267,6 +267,17 @@ pub fn generate_constraints(
             Ok(Type::Dict(kvs))
         }
 
+        Expr::Named(..) => {
+            // Named expressions are for values created by constructors of sum types
+            // (e.g. Result or Option). They should not be present in the source tree.
+            //
+            // TODO: Consider using a separate type for representing values created at
+            // runtime vs. expressions parsed from the source file. Some expressions
+            // (if/then/else) will not be part of the value type, and some values (Named, Curry)
+            // will not be part of the expression type.
+            unimplemented!("Named expressions are not expected to be present in the AST")
+        }
+
         Expr::Tuple(id, _span, exprs) => {
             let mut types = Vec::new();
 

--- a/rex-type-system/src/trace.rs
+++ b/rex-type-system/src/trace.rs
@@ -150,6 +150,9 @@ pub fn sprint_expr_with_type(expr: &Expr, env: &ExprTypeEnv, subst: Option<&Subs
             );
             s
         }
+        Expr::Named(..) => {
+            unimplemented!("Named expressions are not expected to be present in the AST")
+        }
         Expr::Var(Var { id, name, .. }) => format!(
             "{}:{}",
             name,

--- a/rex-type-system/src/types.rs
+++ b/rex-type-system/src/types.rs
@@ -587,6 +587,13 @@ where
     }
 }
 
+impl ToType for ()
+{
+    fn to_type() -> Type {
+        Type::Tuple(vec![])
+    }
+}
+
 impl<T0> ToType for (T0,)
 where
     T0: ToType,

--- a/rex-type-system/src/unify.rs
+++ b/rex-type-system/src/unify.rs
@@ -75,6 +75,17 @@ pub fn unify_eq(t1: &Type, t2: &Type, subst: &mut Subst) -> Result<(), String> {
             unify_eq(&b1, &b2, subst)
         }
 
+        // Result
+        (Type::Result(a1, b1), Type::Result(a2, b2)) => {
+            unify_eq(&a1, &a2, subst)?;
+            unify_eq(&b1, &b2, subst)
+        }
+
+        // Option
+        (Type::Option(a1), Type::Option(a2)) => {
+            unify_eq(&a1, &a2, subst)
+        }
+
         // Type variable case requires occurs check
         (Type::Var(v1), Type::Var(v2)) => {
             if v1 != v2 {

--- a/rex-type-system/src/unify.rs
+++ b/rex-type-system/src/unify.rs
@@ -32,7 +32,7 @@ pub fn unify_constraints(constraint_system: &ConstraintSystem) -> Result<Subst, 
                     // overloaded type variables. This is because we are resolving
                     // all constraints, not just the ones that are actually used by
                     // the expression.
-                    unify_one_of(t1, t2_possibilties, &mut subst);
+                    unify_one_of(t1, t2_possibilties, &mut subst)?;
                 }
             }
         }


### PR DESCRIPTION
Add expression and type system support for `Result` and `Option`, and constructor functions `Ok`/`Err` (for `Result`) and `Some`/`None` (for `Option`).
    
Add `map_result` and `map_option` for the respective types; these have to be named as such for now since we don't yet have support for overloading polymorphic functions like `map`, which requires type classes.

This PR now includes `and_then_result`, `and_then_option`, `or_else_result`, and `or_else_option`.