### PR TITLE
Uuid, DateTime, foldl/foldr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -196,7 +196,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -686,6 +686,7 @@ version = "0.1.0"
 dependencies = [
  "async-recursion",
  "async-trait",
+ "chrono",
  "futures",
  "rand 0.9.0",
  "rex-ast",
@@ -697,6 +698,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -732,6 +734,7 @@ dependencies = [
 name = "rex-type-system"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rand 0.8.5",
  "rex-ast",
  "rex-lexer",
@@ -1084,6 +1087,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-sys"

--- a/rex-ast/src/expr.rs
+++ b/rex-ast/src/expr.rs
@@ -7,6 +7,8 @@ use rex_lexer::span::{Position, Span};
 use rpds::HashTrieMapSync;
 
 use crate::id::Id;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
 
 pub type Scope = HashTrieMapSync<String, Expr>;
 
@@ -73,6 +75,8 @@ pub enum Expr {
     Int(Id, Span, i64),       // -420
     Float(Id, Span, f64),     // 3.14
     String(Id, Span, String), // "hello"
+    Uuid(Id, Span, Uuid),
+    DateTime(Id, Span, DateTime<Utc>),
 
     Tuple(Id, Span, Vec<Expr>),             // (e1, e2, e3)
     List(Id, Span, Vec<Expr>),              // [e1, e2, e3]
@@ -100,6 +104,8 @@ impl Expr {
             | Self::Int(id, ..)
             | Self::Float(id, ..)
             | Self::String(id, ..)
+            | Self::Uuid(id, ..)
+            | Self::DateTime(id, ..)
             | Self::Tuple(id, ..)
             | Self::List(id, ..)
             | Self::Dict(id, ..)
@@ -120,6 +126,8 @@ impl Expr {
             | Self::Int(id, ..)
             | Self::Float(id, ..)
             | Self::String(id, ..)
+            | Self::Uuid(id, ..)
+            | Self::DateTime(id, ..)
             | Self::Tuple(id, ..)
             | Self::List(id, ..)
             | Self::Dict(id, ..)
@@ -140,6 +148,8 @@ impl Expr {
             | Self::Int(_, span, ..)
             | Self::Float(_, span, ..)
             | Self::String(_, span, ..)
+            | Self::Uuid(_, span, ..)
+            | Self::DateTime(_, span, ..)
             | Self::Tuple(_, span, ..)
             | Self::List(_, span, ..)
             | Self::Dict(_, span, ..)
@@ -160,6 +170,8 @@ impl Expr {
             | Self::Int(_, span, ..)
             | Self::Float(_, span, ..)
             | Self::String(_, span, ..)
+            | Self::Uuid(_, span, ..)
+            | Self::DateTime(_, span, ..)
             | Self::Tuple(_, span, ..)
             | Self::List(_, span, ..)
             | Self::Dict(_, span, ..)
@@ -193,6 +205,8 @@ impl Expr {
             Self::Int(id, ..) => *id = Id::default(),
             Self::Float(id, ..) => *id = Id::default(),
             Self::String(id, ..) => *id = Id::default(),
+            Self::Uuid(id, ..) => *id = Id::default(),
+            Self::DateTime(id, ..) => *id = Id::default(),
             Self::Tuple(id, _span, elems) => {
                 *id = Id::default();
                 for elem in elems {
@@ -257,6 +271,8 @@ impl Expr {
             Self::Int(_, span, ..) => *span = Span::default(),
             Self::Float(_, span, ..) => *span = Span::default(),
             Self::String(_, span, ..) => *span = Span::default(),
+            Self::Uuid(_, span, ..) => *span = Span::default(),
+            Self::DateTime(_, span, ..) => *span = Span::default(),
             Self::Tuple(_, span, elems) => {
                 *span = Span::default();
                 for elem in elems {
@@ -323,6 +339,8 @@ impl Display for Expr {
             Self::Int(_id, _span, x) => x.fmt(f),
             Self::Float(_id, _span, x) => x.fmt(f),
             Self::String(_id, _span, x) => x.fmt(f),
+            Self::Uuid(_id, _span, x) => x.fmt(f),
+            Self::DateTime(_id, _span, x) => x.fmt(f),
             Self::List(_id, _span, xs) => {
                 '['.fmt(f)?;
                 for (i, x) in xs.iter().enumerate() {

--- a/rex-engine/Cargo.toml
+++ b/rex-engine/Cargo.toml
@@ -17,3 +17,5 @@ thiserror = { version = "1.0" }
 tokio = { version = "1.27.0", features = ["macros", "rt", "sync"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+chrono = "0.4.40"
+uuid = { version = "1.7", features = ["serde", "v4"] }

--- a/rex-engine/src/codec.rs
+++ b/rex-engine/src/codec.rs
@@ -6,6 +6,8 @@ use std::{
 use rex_ast::{expr::Expr, id::Id};
 use rex_lexer::span::Span;
 use rex_type_system::types::{ToType, Type};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
 
 use crate::error::Error;
 
@@ -91,6 +93,18 @@ impl Encode for &str {
 impl Encode for String {
     fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
         Ok(Expr::String(id, span, self))
+    }
+}
+
+impl Encode for Uuid {
+    fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
+        Ok(Expr::Uuid(id, span, self))
+    }
+}
+
+impl Encode for DateTime<Utc> {
+    fn try_encode(self, id: Id, span: Span) -> Result<Expr, Error> {
+        Ok(Expr::DateTime(id, span, self))
     }
 }
 
@@ -378,6 +392,30 @@ impl Decode for String {
             Expr::String(_, _, x) => Ok(x.clone()),
             _ => Err(Error::ExpectedTypeGotValue {
                 expected: Type::Int,
+                got: v.clone(),
+            }),
+        }
+    }
+}
+
+impl Decode for Uuid {
+    fn try_decode(v: &Expr) -> Result<Self, Error> {
+        match v {
+            Expr::Uuid(_, _, u) => Ok(u.clone()),
+            _ => Err(Error::ExpectedTypeGotValue {
+                expected: Self::to_type(),
+                got: v.clone(),
+            }),
+        }
+    }
+}
+
+impl Decode for DateTime<Utc> {
+    fn try_decode(v: &Expr) -> Result<Self, Error> {
+        match v {
+            Expr::DateTime(_, _, dt) => Ok(dt.clone()),
+            _ => Err(Error::ExpectedTypeGotValue {
+                expected: Self::to_type(),
                 got: v.clone(),
             }),
         }

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -18,6 +18,8 @@ use crate::{
 use rex_ast::expr::Expr;
 use rex_ast::id::Id;
 use rex_lexer::span::Span;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
 
 macro_rules! impl_register_fn_core {
     ($self:expr, $n:expr, $f:expr, $name:ident $(,$($param:ident),*)?) => {{
@@ -396,6 +398,14 @@ where
                 }
             })
         })?;
+
+        // Uuid
+        this.register_fn1("string", |_ctx: &Context<_>, x: Uuid| Ok(format!("{}", x)))?;
+        this.register_fn0("random_uuid", |_ctx: &Context<_>| Ok(Uuid::new_v4()))?;
+
+        // DateTime
+        this.register_fn1("string", |_ctx: &Context<_>, x: DateTime<Utc>| Ok(format!("{}", x)))?;
+        this.register_fn0("now", |_ctx: &Context<_>| Ok(Utc::now()))?;
 
         Ok(this)
     }

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -305,6 +305,32 @@ where
             })
         })?;
 
+        this.register_fn_async3("foldl", |ctx, f: Func<A, Func<B, A>>, base: A, xs: Vec<B>| {
+            Box::pin(async move {
+                let mut res = base;
+                for x in xs {
+                    let ares1 = apply(ctx, &f, &res).await?;
+                    let ares2 = apply(ctx, &ares1, &x).await?;
+                    res = A(ares2)
+                }
+                Ok(res)
+
+            })
+        })?;
+
+        this.register_fn_async3("foldr", |ctx, f: Func<A, Func<B, B>>, base: B, xs: Vec<A>| {
+            Box::pin(async move {
+                let mut res = base;
+                for x in xs.iter().rev() {
+                    let ares1 = apply(ctx, &f, x).await?;
+                    let ares2 = apply(ctx, &ares1, &res).await?;
+                    res = B(ares2);
+                }
+                Ok(res)
+
+            })
+        })?;
+
         this.register_fn_async3(".", |ctx, f: Func<B, C>, g: Func<A, B>, x: A| {
             Box::pin(async move {
                 let x = apply(ctx, &g, &x).await?;

--- a/rex-engine/src/eval.rs
+++ b/rex-engine/src/eval.rs
@@ -1343,6 +1343,25 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_fold() -> Result<(), String> {
+        let (res, res_type) =
+            parse_infer_and_eval(r#"foldl (-) 200.0 [100.0, 40.0, 8.0, 3.0]"#)
+                .await
+                .unwrap();
+        assert_eq!(res_type, float!());
+        assert_expr_eq!(res, f!(49.0); ignore span);
+
+        let (res, res_type) =
+            parse_infer_and_eval(r#"foldr (-) 200.0 [100.0, 40.0, 8.0, 3.0]"#)
+                .await
+                .unwrap();
+        assert_eq!(res_type, float!());
+        assert_expr_eq!(res, f!(265.0); ignore span);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_lambda_let_in_var() -> Result<(), String> {
         let (res, res_type) =
             parse_infer_and_eval(r#"(λx → let y = id x in y + y) 6.9"#)

--- a/rex-engine/src/eval.rs
+++ b/rex-engine/src/eval.rs
@@ -644,7 +644,6 @@ pub mod test {
         assert_eq!(res_type, float!());
         assert_expr_eq!(res, f!(20.080000000000002); ignore span);
 
-        // FIXME(loong): this test is not passing.
         let (res, res_type) = parse_infer_and_eval(r#"let f = λx → id (x + x) in f (6.9 + 3.14)"#)
             .await
             .unwrap();
@@ -786,11 +785,6 @@ pub mod test {
         assert_expr_eq!(res, d!(a = u!(420), b = f!(3.14), c = s!("hello")); ignore span);
     }
 
-    // FIXME(loong): this test is not passing. This is caused by `num_params`
-    // reporting all the parameters of the returned function. This is actually
-    // what you want to do. But it means we need a better "edge case" when
-    // calling curried expressions. Probably some kind of "call it in a loop
-    // until all arguments are gone".
     #[tokio::test]
     async fn test_f_passthrough() {
         let (res, res_type) = parse_infer_and_eval(r#"(id (&&)) true true"#)
@@ -1272,172 +1266,74 @@ pub mod test {
 
     #[tokio::test]
     async fn test_map_map() -> Result<(), String> {
-        let mut parser = Parser::new(
-            Token::tokenize("let f = (λx → -x) in map f (map f [3.14, 6.9, 42.0, 1.0])").unwrap(),
-        );
-        let expr = parser.parse_expr().unwrap();
-
-        let builder = Builder::with_prelude().unwrap();
-        let (mut constraint_system, ftable, type_env) = builder.build();
-
-        let mut expr_type_env = ExprTypeEnv::new();
-
-        let ty = generate_constraints(&expr, &type_env, &mut expr_type_env, &mut constraint_system)
-            .unwrap();
-
-        let subst = unify::unify_constraints(&constraint_system)?;
-        let final_type = unify::apply_subst(&ty, &subst);
-        assert_eq!(final_type, list![Type::Float]);
-
-        let res = eval(
-            &Context {
-                scope: Scope::new_sync(),
-                ftable,
-                subst,
-                env: Arc::new(RwLock::new(expr_type_env)),
-                state: (),
-            },
-            &expr,
-        )
-        .await;
-        match res {
-            Ok(Expr::List(_, _, res)) => {
-                assert!(res.len() == 4);
-                assert!(matches!(res[0], Expr::Float(_, _, 3.14)));
-                assert!(matches!(res[1], Expr::Float(_, _, 6.9)));
-                assert!(matches!(res[2], Expr::Float(_, _, 42.0)));
-                assert!(matches!(res[3], Expr::Float(_, _, 1.0)));
-            }
-            Err(e) => return Err(format!("{:?}", e)),
-            _ => panic!("Expected [3.14, 6.9, 42.0, 1.0], got {:?}", res),
-        }
+        let (res, res_type) =
+            parse_infer_and_eval(r#"let f = (λx → -x) in map f (map f [3.14, 6.9, 42.0, 1.0])"#)
+                .await
+                .unwrap();
+        assert_eq!(res_type, list!(float!()));
+        assert_expr_eq!(res, l!(f!(3.14), f!(6.9), f!(42.0), f!(1.0)); ignore span);
 
         Ok(())
     }
 
     #[tokio::test]
     async fn test_map_extensive() -> Result<(), String> {
-        let mut parser = Parser::new(
-            Token::tokenize(
-                "map (let g = λx → 2.0 * (id x) - x in g) (let f = λx → -(id x), h = map f (map f [-1, -2, -3, -4]) in map f (map (λx → f (id x)) [3.28 - 0.14, id 6.9, (λx → x) 42.0, f (f 1.0)]))",
-            )
-            .unwrap(),
-        );
-        let expr = parser.parse_expr().unwrap();
-
-        let builder = Builder::with_prelude().unwrap();
-        let (mut constraint_system, ftable, type_env) = builder.build();
-
-        let mut expr_type_env = ExprTypeEnv::new();
-
-        let ty = generate_constraints(&expr, &type_env, &mut expr_type_env, &mut constraint_system)
-            .unwrap();
-
-        let subst = unify::unify_constraints(&constraint_system)?;
-        let final_type = unify::apply_subst(&ty, &subst);
-
-        println!(
-            "EXPR\n{}",
-            sprint_expr_with_type(&expr, &expr_type_env, Some(&subst))
-        );
-
-        assert_eq!(final_type, list![Type::Float]);
-
-        let res = eval(
-            &Context {
-                scope: Scope::new_sync(),
-                ftable,
-                subst,
-                env: Arc::new(RwLock::new(expr_type_env)),
-                state: (),
-            },
-            &expr,
-        )
-        .await;
-        match res {
-            Ok(Expr::List(_, _, res)) => {
-                assert!(res.len() == 4);
-                assert!(matches!(res[0], Expr::Float(_, _, 3.1399999999999997)));
-                assert!(matches!(res[1], Expr::Float(_, _, 6.9)));
-                assert!(matches!(res[2], Expr::Float(_, _, 42.0)));
-                assert!(matches!(res[3], Expr::Float(_, _, 1.0)));
-            }
-            Err(e) => return Err(format!("{:?}", e)),
-            _ => panic!("Expected (6.9, 420, true), got {:?}", res),
-        }
-
+        let (res, res_type) =
+            parse_infer_and_eval(r#"
+                map
+                    (let
+                        g = λx → 2.0 * (id x) - x
+                    in
+                        g)
+                    (let
+                        f = λx → -(id x),
+                        h = map f (map f [-1, -2, -3, -4])
+                    in
+                        map
+                            f
+                            (map
+                                (λx → f (id x))
+                                [3.28 - 0.14, id 6.9, (λx → x) 42.0, f (f 1.0)]))
+                "#)
+                .await
+                .unwrap();
+        assert_eq!(res_type, list!(float!()));
+        assert_expr_eq!(res, l!(f!(3.1399999999999997), f!(6.9), f!(42.0), f!(1.0)); ignore span);
         Ok(())
     }
 
     #[tokio::test]
     async fn test_lambda_let_in_var() -> Result<(), String> {
-        let mut parser = Parser::new(Token::tokenize("(λx → let y = id x in y + y) 6.9").unwrap());
-        let expr = parser.parse_expr().unwrap();
-
-        let builder = Builder::with_prelude().unwrap();
-        let (mut constraint_system, ftable, type_env) = builder.build();
-
-        let mut expr_type_env = ExprTypeEnv::new();
-
-        let ty = generate_constraints(&expr, &type_env, &mut expr_type_env, &mut constraint_system)
-            .unwrap();
-
-        let subst = unify::unify_constraints(&constraint_system)?;
-        let final_type = unify::apply_subst(&ty, &subst);
-
-        println!(
-            "EXPR\n{}\n",
-            sprint_expr_with_type(&expr, &expr_type_env, Some(&subst))
-        );
-
-        assert_eq!(final_type, Type::Float);
-
-        let res = eval(
-            &Context {
-                scope: Scope::new_sync(),
-                ftable,
-                subst,
-                env: Arc::new(RwLock::new(expr_type_env)),
-                state: (),
-            },
-            &expr,
-        )
-        .await;
-
-        match res {
-            Ok(Expr::Float(_, _, 13.8)) => Ok(()),
-            Err(e) => Err(format!("{:?}", e)),
-            _ => panic!("Expected 13.8, got {:?}", res),
-        }
+        let (res, res_type) =
+            parse_infer_and_eval(r#"(λx → let y = id x in y + y) 6.9"#)
+                .await
+                .unwrap();
+        assert_eq!(res_type, float!());
+        assert_expr_eq!(res, f!(13.8); ignore span);
+        Ok(())
     }
 
     /// This test is meant to reflect the kind of usage pattern that we see in
     /// production code. However, it should not be taken as a comprehensive.
     #[tokio::test]
     async fn test_big_boy() {
-        let (res, res_type) = parse_infer_and_eval(
-            r#"
-(λxs ys zs →
-    let
-        t = map (λx → ((get 0 xs) * x)) xs,
-
-        u = ys ++ [420],
-
-        v = take 2 zs,
-
-        f = (λx →
-            let
-                a = (id x) 
-            in
-                a + a
-        ),
-
-        g = (++) ((++) xs t)
-    in
-        zip (g xs) [[u], v]
-) [2.0, 3.0, 4.0] [4, 5, 6] [[6, 7, 8], [9, 10, 11], [12, 13, 14]]
-"#,
-        )
+        let (res, res_type) = parse_infer_and_eval(r#"
+            (λxs ys zs →
+                let
+                    t = map (λx → ((get 0 xs) * x)) xs,
+                    u = ys ++ [420],
+                    v = take 2 zs,
+                    f = (λx →
+                        let
+                            a = (id x)
+                        in
+                            a + a
+                    ),
+                    g = (++) ((++) xs t)
+                in
+                    zip (g xs) [[u], v]
+            ) [2.0, 3.0, 4.0] [4, 5, 6] [[6, 7, 8], [9, 10, 11], [12, 13, 14]]
+            "#)
         .await
         .unwrap();
         assert_eq!(res_type, list!(tuple!(float!(), list!(list!(uint!())))));

--- a/rex-type-system/Cargo.toml
+++ b/rex-type-system/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4.40"
 rand = "0.8.5"
 rex-ast = { path = "../rex-ast" }
 rex-lexer = { path = "../rex-lexer" }

--- a/rex-type-system/src/constraint.rs
+++ b/rex-type-system/src/constraint.rs
@@ -457,6 +457,14 @@ pub fn generate_constraints(
             expr_env.insert(*id, Type::String);
             Ok(Type::String)
         }
+        Expr::Uuid(id, _span, _x) => {
+            expr_env.insert(*id, Type::Uuid);
+            Ok(Type::Uuid)
+        }
+        Expr::DateTime(id, _span, _x) => {
+            expr_env.insert(*id, Type::DateTime);
+            Ok(Type::DateTime)
+        }
 
         Expr::Curry(..) => {
             todo!("generate_constraints for Expr::Curry just like we do for Expr::App")
@@ -515,7 +523,13 @@ fn free_vars(ty: &Type) -> HashSet<Id> {
             vars
         }
 
-        Type::Bool | Type::Uint | Type::Int | Type::Float | Type::String => HashSet::new(),
+        Type::Bool |
+        Type::Uint |
+        Type::Int |
+        Type::Float |
+        Type::String |
+        Type::Uuid |
+        Type::DateTime => HashSet::new(),
     }
 }
 
@@ -643,7 +657,13 @@ fn instantiate(ty: &Type, constraint_system: &mut ConstraintSystem) -> Type {
                     .collect(),
             ),
 
-            Type::Bool | Type::Uint | Type::Int | Type::Float | Type::String => ty.clone(),
+            Type::Bool |
+            Type::Uint |
+            Type::Int |
+            Type::Float |
+            Type::String |
+            Type::Uuid |
+            Type::DateTime => ty.clone(),
         };
         result
     }

--- a/rex-type-system/src/trace.rs
+++ b/rex-type-system/src/trace.rs
@@ -77,6 +77,22 @@ pub fn sprint_expr_with_type(expr: &Expr, env: &ExprTypeEnv, subst: Option<&Subs
                 .map(|t| t.to_string())
                 .unwrap_or("_".to_string())
         ),
+        Expr::Uuid(id, _, u) => format!(
+            "{}:{}",
+            u,
+            env.get(id)
+                .and_then(|t| subst.map(|s| apply_subst(t, s)))
+                .map(|t| t.to_string())
+                .unwrap_or("_".to_string())
+        ),
+        Expr::DateTime(id, _, dt) => format!(
+            "{}:{}",
+            dt,
+            env.get(id)
+                .and_then(|t| subst.map(|s| apply_subst(t, s)))
+                .map(|t| t.to_string())
+                .unwrap_or("_".to_string())
+        ),
         Expr::List(id, _, xs) => {
             let mut s = String::new();
             s.push('[');

--- a/rex-type-system/src/types.rs
+++ b/rex-type-system/src/types.rs
@@ -4,6 +4,8 @@ use std::{
 };
 
 use rex_ast::id::Id;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
 
 pub type TypeEnv = HashMap<String, Type>;
 
@@ -29,6 +31,8 @@ pub enum Type {
     Int,
     Float,
     String,
+    Uuid,
+    DateTime,
 }
 
 impl Type {
@@ -94,6 +98,8 @@ impl Type {
             Type::Int => {}
             Type::Float => {}
             Type::String => {}
+            Type::Uuid => {}
+            Type::DateTime => {}
         }
     }
 
@@ -110,6 +116,8 @@ impl Type {
             (Self::Int, Self::Int) => Ok(()),
             (Self::Float, Self::Float) => Ok(()),
             (Self::String, Self::String) => Ok(()),
+            (Self::Uuid, Self::Uuid) => Ok(()),
+            (Self::DateTime, Self::DateTime) => Ok(()),
 
             (Self::Arrow(a1, b1), Self::Arrow(a2, b2)) => {
                 a1.maybe_compatible(a2)?;
@@ -236,6 +244,8 @@ impl Type {
             Type::Int => {}
             Type::Float => {}
             Type::String => {}
+            Type::Uuid => {}
+            Type::DateTime => {}
         }
     }
 }
@@ -248,6 +258,8 @@ impl Display for Type {
             Type::Int => "int".fmt(f),
             Type::Float => "float".fmt(f),
             Type::String => "string".fmt(f),
+            Type::Uuid => "uuid".fmt(f),
+            Type::DateTime => "datetime".fmt(f),
             Type::Option(x) => {
                 "Option (".fmt(f)?;
                 x.fmt(f)?;
@@ -465,6 +477,18 @@ impl ToType for str {
 impl ToType for String {
     fn to_type() -> Type {
         Type::String
+    }
+}
+
+impl ToType for Uuid {
+    fn to_type() -> Type {
+        Type::Uuid
+    }
+}
+
+impl ToType for DateTime<Utc> {
+    fn to_type() -> Type {
+        Type::DateTime
     }
 }
 

--- a/rex-type-system/src/unify.rs
+++ b/rex-type-system/src/unify.rs
@@ -52,6 +52,8 @@ pub fn unify_eq(t1: &Type, t2: &Type, subst: &mut Subst) -> Result<(), String> {
         (Type::Int, Type::Int) => Ok(()),
         (Type::Float, Type::Float) => Ok(()),
         (Type::String, Type::String) => Ok(()),
+        (Type::Uuid, Type::Uuid) => Ok(()),
+        (Type::DateTime, Type::DateTime) => Ok(()),
 
         // Tuples
         (Type::Tuple(ts1), Type::Tuple(ts2)) => {
@@ -193,7 +195,13 @@ pub fn apply_subst(t: &Type, subst: &Subst) -> Type {
         ),
         Type::Tuple(ts) => Type::Tuple(ts.iter().map(|t| apply_subst(t, subst)).collect()),
 
-        Type::Bool | Type::Uint | Type::Int | Type::Float | Type::String => t.clone(),
+        Type::Bool |
+        Type::Uint |
+        Type::Int |
+        Type::Float |
+        Type::String |
+        Type::Uuid |
+        Type::DateTime => t.clone(),
     }
 }
 
@@ -222,7 +230,13 @@ pub fn occurs_check(var: Id, t: &Type) -> bool {
         Type::Dict(kts) => kts.values().any(|t| occurs_check(var, t)),
         Type::Tuple(ts) => ts.iter().any(|t| occurs_check(var, t)),
 
-        Type::Bool | Type::Uint | Type::Int | Type::Float | Type::String => false,
+        Type::Bool |
+        Type::Uint |
+        Type::Int |
+        Type::Float |
+        Type::String |
+        Type::Uuid |
+        Type::DateTime => false,
     }
 }
 


### PR DESCRIPTION
Add support for the `Uuid` and `DateTime` types, along with `random_uuid` and `now` functions. We'll rename `random_uuid` to `random` once we have type classes, at which point it'll make more sense to add a `random` function for the other types as well.

Add the `foldl` and `foldr` functions for working with lists.

Tidy up some of the eval tests that pre-dated the macros for types and expressions, making use of the macros now.