### PR TITLE
Add Program struct

### DIFF
--- a/rex-engine/src/error.rs
+++ b/rex-engine/src/error.rs
@@ -1,14 +1,25 @@
 use rex_ast::expr::{Expr, Var};
+use rex_lexer::span::Span;
+use rex_parser::error::ParserErr;
 use rex_type_system::types::Type;
+use serde_json::Value;
 
 // TODO(loong): re-implement traces so that developers can get meaningful
 // errors when something goes wrong.
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum Error {
+    #[error("unexpected token {0}")]
+    UnexpectedToken(Span),
+    #[error("parsing failed: {0:?}")]
+    Parser(Vec<ParserErr>),
+    #[error("type inference failed: {0:?}")]
+    TypeInference(String),
     #[error("variable not found {var}")]
     VarNotFound { var: Var },
     #[error("expected {expected}, got {got}")]
     ExpectedTypeGotValue { expected: Type, got: Expr },
+    #[error("expected {expected}, got {got}")]
+    ExpectedTypeGotJSON { expected: Type, got: Value },
     #[error("missing argument {argument}")]
     MissingArgument { argument: usize },
     #[error("{0}")]

--- a/rex-engine/src/lib.rs
+++ b/rex-engine/src/lib.rs
@@ -3,4 +3,5 @@ pub mod engine;
 pub mod error;
 pub mod eval;
 pub mod ftable;
+pub mod program;
 pub mod util;

--- a/rex-engine/src/program.rs
+++ b/rex-engine/src/program.rs
@@ -1,0 +1,74 @@
+use crate::engine::Builder;
+use crate::error::Error;
+use crate::eval::eval;
+use crate::eval::Context;
+use crate::ftable::Ftable;
+use rex_ast::expr::{Expr, Scope};
+use rex_lexer::LexicalError;
+use rex_lexer::Token;
+use rex_parser::Parser;
+use rex_type_system::unify::Subst;
+use rex_type_system::{
+    constraint::generate_constraints,
+    types::{ExprTypeEnv, Type},
+    unify,
+};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct Program<State>
+where
+    State: Clone + Send + Sync + 'static,
+{
+    pub ftable: Ftable<State>,
+    pub res_type: Type,
+    pub expr: Expr,
+    pub expr_type_env: ExprTypeEnv,
+    pub subst: Subst,
+}
+
+impl<State> Program<State>
+where
+    State: Clone + Send + Sync + 'static,
+{
+    pub fn compile(builder: Builder<State>, code: &str) -> Result<Self, Error> {
+        let tokens = Token::tokenize(code).map_err(|e| match e {
+            LexicalError::UnexpectedToken(s) => Error::UnexpectedToken(s),
+        })?;
+        let mut parser = Parser::new(tokens);
+        let expr = parser.parse_expr().map_err(|e| match e {
+            rex_parser::error::Error::Parser(e) => Error::Parser(e),
+        })?;
+
+        let (mut constraint_system, ftable, type_env) = builder.build();
+
+        let mut expr_type_env = ExprTypeEnv::new();
+        let ty = generate_constraints(&expr, &type_env, &mut expr_type_env, &mut constraint_system)
+            .map_err(|e| Error::TypeInference(e))?;
+        let subst =
+            unify::unify_constraints(&constraint_system).map_err(|e| Error::TypeInference(e))?;
+
+        let res_type = unify::apply_subst(&ty, &subst);
+        Ok(Program {
+            ftable,
+            res_type,
+            expr,
+            expr_type_env,
+            subst,
+        })
+    }
+
+    pub async fn run(self, state: State) -> Result<Expr, Error> {
+        eval(
+            &Context {
+                scope: Scope::new_sync(),
+                ftable: self.ftable,
+                subst: self.subst,
+                env: Arc::new(RwLock::new(self.expr_type_env)),
+                state: state,
+            },
+            &self.expr,
+        )
+        .await
+    }
+}

--- a/rex-engine/src/util.rs
+++ b/rex-engine/src/util.rs
@@ -1,17 +1,8 @@
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use crate::engine::Builder;
 use crate::error::Error;
-use crate::eval::Context;
-use crate::eval::eval;
-use rex_ast::expr::{Expr, Scope};
-use rex_lexer::Token;
-use rex_parser::Parser;
-use rex_type_system::{
-    constraint::generate_constraints,
-    types::{ExprTypeEnv, Type},
-    unify,
-};
+use crate::program::Program;
+use rex_ast::expr::Expr;
+use rex_type_system::types::Type;
 
 /// Helper function for parsing, inferring, and evaluating a given code
 /// snippet. Pretty much all of the test suites can use this flow for
@@ -29,29 +20,9 @@ pub async fn parse_infer_and_eval_with_builder(
     builder: Builder<()>,
     code: &str,
 ) -> Result<(Expr, Type), Error> {
-    let mut parser = Parser::new(Token::tokenize(code).unwrap());
-    let expr = parser.parse_expr().unwrap();
-
-    let (mut constraint_system, ftable, type_env) = builder.build();
-
-    let mut expr_type_env = ExprTypeEnv::new();
-    let ty = generate_constraints(&expr, &type_env, &mut expr_type_env, &mut constraint_system)
-        .unwrap();
-
-    let subst = unify::unify_constraints(&constraint_system).unwrap();
-    let res_type = unify::apply_subst(&ty, &subst);
-
-    let res = eval(
-        &Context {
-            scope: Scope::new_sync(),
-            ftable,
-            subst,
-            env: Arc::new(RwLock::new(expr_type_env)),
-            state: (),
-        },
-        &expr,
-    )
-    .await;
+    let program = Program::compile(builder, code)?;
+    let res_type = program.res_type.clone();
+    let res = program.run(()).await;
 
     res.map(|res| (res, res_type))
 }


### PR DESCRIPTION
Add an API to encapsulate tokenization, parsing, and type inference so that it doesn't have to be duplicated in every test. We already had functions for this in rex itself, but this API is a little more flexible to cater for what the tests in tengu need.