### PR TITLE
fix: Serialize enums to JSON

### DIFF
--- a/rex-engine/src/value.rs
+++ b/rex-engine/src/value.rs
@@ -471,7 +471,7 @@ impl TryFrom<Value> for serde_json::Value {
                         .map(serde_json::Value::try_from)
                         .collect::<Result<_, _>>()?,
                 ),
-                None => serde_json::Value::Null,
+                None => serde_json::Value::String(xs.name.clone()),
             }),
             Value::Id(_) => Err(serde_json::Error::custom("cannot serialize id to JSON")),
             Value::Function(_) => Err(serde_json::Error::custom(


### PR DESCRIPTION
When serializing a Data value that does not have any fields to JSON, return a string instead of null. This is necessary for the new disposition field support in tengu, because Disposition is an enum passed to the metadata constructor.