### PR TITLE
feat: list_max_by and list_min_by

### DIFF
--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -1289,6 +1289,78 @@ where
             }),
         );
 
+        this.register(
+            ns,
+            "list_min_by",
+            fn_async2(|ctx, f: Func<A, i64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut min_elem = xs[0].clone();
+                    let mut min_key = i64::try_decode(&apply(ctx, &f, &min_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = i64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key < min_key {
+                            min_key = key;
+                            min_elem = x.clone();
+                        }
+                    }
+                    Ok(min_elem)
+                })
+            }),
+        );
+
+        this.register(
+            ns,
+            "list_min_by",
+            fn_async2(|ctx, f: Func<A, u64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut min_elem = xs[0].clone();
+                    let mut min_key = u64::try_decode(&apply(ctx, &f, &min_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = u64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key < min_key {
+                            min_key = key;
+                            min_elem = x.clone();
+                        }
+                    }
+                    Ok(min_elem)
+                })
+            }),
+        );
+
+        this.register(
+            ns,
+            "list_min_by",
+            fn_async2(|ctx, f: Func<A, f64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut min_elem = xs[0].clone();
+                    let mut min_key = f64::try_decode(&apply(ctx, &f, &min_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = f64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key < min_key {
+                            min_key = key;
+                            min_elem = x.clone();
+                        }
+                    }
+                    Ok(min_elem)
+                })
+            }),
+        );
+
         Ok(this)
     }
 

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -1217,54 +1217,11 @@ where
             }),
         );
 
-        this.register(
-            ns,
-            "list_max_by",
-            fn_async2(|ctx, f: Func<A, i64>, xs: Vec<A>| {
-                Box::pin(async move {
-                    if xs.is_empty() {
-                        return Err("List is empty".into());
-                    }
-
-                    let mut max_elem = xs[0].clone();
-                    let mut max_key = i64::try_decode(&apply(ctx, &f, &max_elem, None).await?)?;
-
-                    for x in &xs[1..] {
-                        let key = i64::try_decode(&apply(ctx, &f, x, None).await?)?;
-                        if key > max_key {
-                            max_key = key;
-                            max_elem = x.clone();
-                        }
-                    }
-                    Ok(max_elem)
-                })
-            }),
-        );
-
-        this.register(
-            ns,
-            "list_max_by",
-            fn_async2(|ctx, f: Func<A, u64>, xs: Vec<A>| {
-                Box::pin(async move {
-                    if xs.is_empty() {
-                        return Err("List is empty".into());
-                    }
-
-                    let mut max_elem = xs[0].clone();
-                    let mut max_key = u64::try_decode(&apply(ctx, &f, &max_elem, None).await?)?;
-
-                    for x in &xs[1..] {
-                        let key = u64::try_decode(&apply(ctx, &f, x, None).await?)?;
-                        if key > max_key {
-                            max_key = key;
-                            max_elem = x.clone();
-                        }
-                    }
-                    Ok(max_elem)
-                })
-            }),
-        );
-
+        // Note: list_max_by and list_min_by only support float (f64) return types.
+        // This limitation exists because the type system cannot disambiguate between
+        // i64, u64, and f64 overloads when the return type comes from a function argument.
+        // Functions like list_max work because they operate directly on lists where the
+        // element type disambiguates the overload.
         this.register(
             ns,
             "list_max_by",
@@ -1289,54 +1246,7 @@ where
             }),
         );
 
-        this.register(
-            ns,
-            "list_min_by",
-            fn_async2(|ctx, f: Func<A, i64>, xs: Vec<A>| {
-                Box::pin(async move {
-                    if xs.is_empty() {
-                        return Err("List is empty".into());
-                    }
-
-                    let mut min_elem = xs[0].clone();
-                    let mut min_key = i64::try_decode(&apply(ctx, &f, &min_elem, None).await?)?;
-
-                    for x in &xs[1..] {
-                        let key = i64::try_decode(&apply(ctx, &f, x, None).await?)?;
-                        if key < min_key {
-                            min_key = key;
-                            min_elem = x.clone();
-                        }
-                    }
-                    Ok(min_elem)
-                })
-            }),
-        );
-
-        this.register(
-            ns,
-            "list_min_by",
-            fn_async2(|ctx, f: Func<A, u64>, xs: Vec<A>| {
-                Box::pin(async move {
-                    if xs.is_empty() {
-                        return Err("List is empty".into());
-                    }
-
-                    let mut min_elem = xs[0].clone();
-                    let mut min_key = u64::try_decode(&apply(ctx, &f, &min_elem, None).await?)?;
-
-                    for x in &xs[1..] {
-                        let key = u64::try_decode(&apply(ctx, &f, x, None).await?)?;
-                        if key < min_key {
-                            min_key = key;
-                            min_elem = x.clone();
-                        }
-                    }
-                    Ok(min_elem)
-                })
-            }),
-        );
-
+        // See note above list_max_by regarding float-only limitation
         this.register(
             ns,
             "list_min_by",

--- a/rex-engine/src/engine.rs
+++ b/rex-engine/src/engine.rs
@@ -1217,6 +1217,78 @@ where
             }),
         );
 
+        this.register(
+            ns,
+            "list_max_by",
+            fn_async2(|ctx, f: Func<A, i64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut max_elem = xs[0].clone();
+                    let mut max_key = i64::try_decode(&apply(ctx, &f, &max_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = i64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key > max_key {
+                            max_key = key;
+                            max_elem = x.clone();
+                        }
+                    }
+                    Ok(max_elem)
+                })
+            }),
+        );
+
+        this.register(
+            ns,
+            "list_max_by",
+            fn_async2(|ctx, f: Func<A, u64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut max_elem = xs[0].clone();
+                    let mut max_key = u64::try_decode(&apply(ctx, &f, &max_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = u64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key > max_key {
+                            max_key = key;
+                            max_elem = x.clone();
+                        }
+                    }
+                    Ok(max_elem)
+                })
+            }),
+        );
+
+        this.register(
+            ns,
+            "list_max_by",
+            fn_async2(|ctx, f: Func<A, f64>, xs: Vec<A>| {
+                Box::pin(async move {
+                    if xs.is_empty() {
+                        return Err("List is empty".into());
+                    }
+
+                    let mut max_elem = xs[0].clone();
+                    let mut max_key = f64::try_decode(&apply(ctx, &f, &max_elem, None).await?)?;
+
+                    for x in &xs[1..] {
+                        let key = f64::try_decode(&apply(ctx, &f, x, None).await?)?;
+                        if key > max_key {
+                            max_key = key;
+                            max_elem = x.clone();
+                        }
+                    }
+                    Ok(max_elem)
+                })
+            }),
+        );
+
         Ok(this)
     }
 

--- a/rex-engine/src/eval.rs
+++ b/rex-engine/src/eval.rs
@@ -1957,17 +1957,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_list_max_by() {
-        // Test with int keys
-        let (res, res_type) = parse_infer_and_eval(
-            r#"
-            list_max_by (\x -> elem0 x) [(int 5, "five"), (int -6, "neg"), (int 9, "nine"), (int 3, "three")]
-            "#,
-        )
-        .await
-        .unwrap();
-        assert_eq!(res_type, tuple!(int!(), string!()));
-        assert_expr_eq!(res, tup!(i!(9), s!("nine")); ignore span);
-
         // Test with float keys
         let (res, res_type) = parse_infer_and_eval(
             r#"
@@ -1993,17 +1982,6 @@ pub mod test {
 
     #[tokio::test]
     async fn test_list_min_by() {
-        // Test with int keys
-        let (res, res_type) = parse_infer_and_eval(
-            r#"
-            list_min_by (\x -> elem0 x) [(int 5, "five"), (int -6, "neg"), (int 9, "nine"), (int 3, "three")]
-            "#,
-        )
-        .await
-        .unwrap();
-        assert_eq!(res_type, tuple!(int!(), string!()));
-        assert_expr_eq!(res, tup!(i!(-6), s!("neg")); ignore span);
-
         // Test with float keys
         let (res, res_type) = parse_infer_and_eval(
             r#"

--- a/rex-engine/src/eval.rs
+++ b/rex-engine/src/eval.rs
@@ -1956,6 +1956,78 @@ pub mod test {
     }
 
     #[tokio::test]
+    async fn test_list_max_by() {
+        // Test with int keys
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_max_by (\x -> elem0 x) [(int 5, "five"), (int -6, "neg"), (int 9, "nine"), (int 3, "three")]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(int!(), string!()));
+        assert_expr_eq!(res, tup!(i!(9), s!("nine")); ignore span);
+
+        // Test with float keys
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_max_by (\x -> elem0 x) [(5.0, "five"), (9.5, "nine"), (-6.5, "neg"), (3.0, "three")]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(float!(), string!()));
+        assert_expr_eq!(res, tup!(f!(9.5), s!("nine")); ignore span);
+
+        // Test with more complex key function
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_max_by (\x -> elem1 x) [("a", 5.0), ("b", 9.5), ("c", -6.5), ("d", 3.0)]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(string!(), float!()));
+        assert_expr_eq!(res, tup!(s!("b"), f!(9.5)); ignore span);
+    }
+
+    #[tokio::test]
+    async fn test_list_min_by() {
+        // Test with int keys
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_min_by (\x -> elem0 x) [(int 5, "five"), (int -6, "neg"), (int 9, "nine"), (int 3, "three")]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(int!(), string!()));
+        assert_expr_eq!(res, tup!(i!(-6), s!("neg")); ignore span);
+
+        // Test with float keys
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_min_by (\x -> elem0 x) [(5.0, "five"), (9.5, "nine"), (-6.5, "neg"), (3.0, "three")]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(float!(), string!()));
+        assert_expr_eq!(res, tup!(f!(-6.5), s!("neg")); ignore span);
+
+        // Test with more complex key function
+        let (res, res_type) = parse_infer_and_eval(
+            r#"
+            list_min_by (\x -> elem1 x) [("a", 5.0), ("b", 9.5), ("c", -6.5), ("d", 3.0)]
+            "#,
+        )
+        .await
+        .unwrap();
+        assert_eq!(res_type, tuple!(string!(), float!()));
+        assert_expr_eq!(res, tup!(s!("c"), f!(-6.5)); ignore span);
+    }
+
+    #[tokio::test]
     async fn test_match_result() {
         let (res, res_type) = parse_infer_and_eval(
             r#"


### PR DESCRIPTION
- added `list_max_by` and `list_min_by` functions, registered 3 overloads for each function, `i64`, `u64`, and `f64`, following existing pattern
- takes a key function (A -> B) and a list [A], returns element A with maximum key value, where B is of the 3 possible types

**tried adding tests but they are failing due to the type-ambiguious nature of the new functions
temporary fix: remove overloads for int and uint, support floats exclusively**

```
// Note: list_max_by and list_min_by only support float (f64) return types.
// This limitation exists because the type system cannot disambiguate between
// i64, u64, and f64 overloads when the return type comes from a function argument.
// Functions like list_max work because they operate directly on lists where the
// element type disambiguates the overload.
